### PR TITLE
doc: fixed typo and inlined filename

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ To pick a different color presentation, use command:
 **Q:** Why color highlight is not shown on my vim?
 
 **A:** First, make sure `"coc.preferences.colorSupport"` is not `false` in your
-coc-sttings.json, then make sure you have `set termguicolors` in your `.vimrc`,
+`coc-settings.json`, then make sure you have `set termguicolors` in your `.vimrc`,
 and your terminal support true color.
 
 **Q:** How to change highlight of the current symbol.


### PR DESCRIPTION
Simple typo fix in `Readme.md` 🙂 