### PR TITLE
feat(settings): Add `colorNames` Setting Option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,10 +55,11 @@ To pick a different color presentation, use command:
 
 ## Options
 
-- `highlight.disableLanguages`, list of filetypes to ignore for this extension.
-- `highlight.document.enable`, set to `false` to disable document symbol
+- `highlight.disableLanguages`, List of filetypes to ignore for this extension.
+- `highlight.document.enable`, Set to `false` to disable document symbol
   highlight.
-- `highlight.colors.enable`, set to `false` to disable color highlight.
+- `highlight.colors.enable`, Set to `false` to disable color highlight.
+- `highlight.colorNames.enable`, Set to `false` to disable highlight of color names.
 
 ## F.A.Q
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
           "items": {
             "type": "string"
           },
-          "description": "list of filetypes to ignore."
+          "description": "List of filetypes to ignore."
         },
         "highlight.document.enable": {
           "type": "boolean",
@@ -57,7 +57,12 @@
         "highlight.colors.enable": {
           "type": "boolean",
           "default": true,
-          "description": "set to false to disable color highlight."
+          "description": "Set to false to disable color highlight."
+        },
+        "highlight.colorNames.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to false to disable highlight of color names."
         }
       }
     }

--- a/server/colors.ts
+++ b/server/colors.ts
@@ -1,15 +1,18 @@
 import { TextDocument, ColorInformation } from 'vscode-languageserver'
 import { DocumentSymbol } from './types'
 import { findColorFunctions, findHwb, findColorHex, getNameColor } from "./matchers"
+import { settings } from '.';
 
 export function parseDocumentColors(document: TextDocument, symbols: DocumentSymbol[]): ColorInformation[] {
   let res: ColorInformation[] = []
-  symbols.forEach(o => {
-    let color = getNameColor(o.text)
-    if (color) {
-      res.push({ color, range: o.range })
-    }
-  })
+  if (settings.colorNamesEnable) {
+    symbols.forEach(o => {
+      let color = getNameColor(o.text)
+      if (color) {
+        res.push({ color, range: o.range })
+      }
+    })
+  }
   res.push(...findColorHex(document))
   res.push(...findColorFunctions(document))
   res.push(...findHwb(document))

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,10 +12,15 @@ namespace FetchKeywordRequest {
 }
 
 const documentMap: Map<string, Document> = new Map()
-const settings: Settings = { highlightEnable: true, colorsEnable: true, disableLanguages: [] }
 const exitCalled = new NotificationType<[number, string], void>(
   'highlight/exitCalled'
 )
+export const settings: Settings = {
+  highlightEnable: true,
+  colorsEnable: true,
+  colorNamesEnable: true,
+  disableLanguages: [],
+}
 
 const nodeExit = process.exit
 process.exit = ((code?: number): void => {
@@ -127,6 +132,7 @@ connection.onDidChangeConfiguration((change: DidChangeConfigurationParams): void
   let { highlight } = change.settings
   settings.highlightEnable = highlight.document.enable
   settings.colorsEnable = highlight.colors.enable
+  settings.colorNamesEnable = highlight.colorNames.enable
   let disableLanguages: string[] = settings.disableLanguages = highlight.disableLanguages
   for (let doc of documentMap.values()) {
     if (disableLanguages.indexOf(doc.languageId) !== -1) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,7 @@ import { Range } from 'vscode-languageserver'
 export interface Settings {
   highlightEnable: boolean
   colorsEnable: boolean
+  colorNamesEnable: boolean
   disableLanguages: string[]
 }
 
@@ -10,4 +11,3 @@ export interface DocumentSymbol {
   text: string
   range: Range
 }
-


### PR DESCRIPTION
Allow users to disable highlighting of color names.

Examples: [red, green, blue] will not be highlighted while hex values
and other methods are still allowed in `parseDocumentColors()`

Resolves #23
Resolves #29