### PR TITLE
Add a link to the `coc_current_word` plugin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,8 @@ To enable highlight current symbol on `CursorHold`, add:
 autocmd CursorHold * silent call CocActionAsync('highlight')
 ```
 
-to your `.vimrc`.
+to your `.vimrc` or use the [coc_current_word plugin](https://github.com/IngoMeyer441/coc_current_word) which provides
+configurable delayed highlighting independently from the user's `updatetime` setting.
 
 To disable coc provide color highlight, add:
 


### PR DESCRIPTION
I wanted to use delayed highlighting, which can be configured independently of the user's `updatetime` setting. Therefore, I created a plugin [coc_current_word](https://github.com/IngoMeyer441/coc_current_word) which uses Vim 8 / Neovim timers for custom delayed highlighting. The plugin is based on the [vim_current_word](https://github.com/dominikduda/vim_current_word) plugin.