### PR TITLE
feat(server): Add support for flutter hex colors

### DIFF
--- a/server/colors.ts
+++ b/server/colors.ts
@@ -1,6 +1,6 @@
 import { TextDocument, ColorInformation } from 'vscode-languageserver'
 import { DocumentSymbol } from './types'
-import { findColorFunctions, findHwb, findColorHex, getNameColor } from "./matchers"
+import { findColorFunctions, findHwb, findColorHex, getNameColor, findColorHexFlutter } from "./matchers"
 import { settings } from '.';
 
 export function parseDocumentColors(document: TextDocument, symbols: DocumentSymbol[]): ColorInformation[] {
@@ -16,5 +16,6 @@ export function parseDocumentColors(document: TextDocument, symbols: DocumentSym
   res.push(...findColorHex(document))
   res.push(...findColorFunctions(document))
   res.push(...findHwb(document))
+  res.push(...findColorHexFlutter(document))
   return res
 }

--- a/server/matchers.ts
+++ b/server/matchers.ts
@@ -6,6 +6,7 @@ const names = Object.keys(webColors)
 const colorHex = /(?<!&|\w)((?:#)([a-f0-9]{6}([a-f0-9]{2})?|[a-f0-9]{3}([a-f0-9]{1})?))\b/gi
 const colorFunctions = /(?:\b(rgb|hsl)a?\([\d]{1,3}(\.\d+)?%?,\s*[\d]{1,3}(\.\d+)?%?,\s*[\d]{1,3}(\.\d+)?%?(,\s*\d?\.?\d+)?\))/gi
 const colorHwb = /(?:\b(hwb)\(\d+,\s*(100|0*\d{1,2})%,\s*(100|0*\d{1,2})%(,\s*0?\.?\d+)?\))/gi
+const colorHexFlutter= /(?<=Color\(\s*0x)(?:[a-fA-F0-9]{1,8})(?=\s*\))/g
 
 export function getNameColor(word: string): VSColor | null {
   if (names.indexOf(word) == -1) return null
@@ -28,14 +29,29 @@ export function findHwb(document: TextDocument): ColorInformation[] {
   return findColors(document, colorHwb)
 }
 
-function findColors(document: TextDocument, regex: RegExp): ColorInformation[] {
+export function findColorHexFlutter(document: TextDocument): ColorInformation[] {
+    colorHexFlutter.lastIndex = 0;
+    let normalizeColorFormat = (colorString: String) => {
+        colorString = colorString.padStart(8, "0")
+        //alpha bytes are on the opposite end for flutter colors
+        let alpha = colorString.slice(0, 2)
+        let rgb = colorString.slice(2, 8)
+        return "#" + rgb + alpha
+    };
+    return findColors(document, colorHexFlutter, normalizeColorFormat);
+}
+
+function findColors(document: TextDocument, regex: RegExp, normalizeColorFormat?: (color: String) => String) : ColorInformation[] {
   let text = document.getText()
   let match = regex.exec(text)
   let result: ColorInformation[] = []
   while (match !== null) {
     const start = match.index
     try {
-      const c = new Color(match[0].toLowerCase())
+      if (normalizeColorFormat == undefined) 
+          normalizeColorFormat = (colorString) => colorString
+      let formattedColor = normalizeColorFormat(match[0].toLowerCase())
+      const c = new Color(formattedColor)
       result.push({
         color: { red: c.red() / 255, green: c.green() / 255, blue: c.blue() / 255, alpha: c.alpha() },
         range: Range.create(document.positionAt(start), document.positionAt(start + match[0].length))

--- a/tests/example.dart
+++ b/tests/example.dart
@@ -1,0 +1,9 @@
+//Mock the flutter Color class
+final Color = (_) => _;
+
+void main() {
+  Color(0xff007bc0);
+  Color(0xff43bbff);
+  Color(0xff597567);
+  Color(0x14fcd93a);
+}


### PR DESCRIPTION
Hello, 

I've added preliminary support for hex formatted colors, so this should work for `Color(0x9DBF9E)` for example. There are other ways of describing colors which I'll look into implementing later. Thanks for the extension.

Also closes #55.